### PR TITLE
Use "0" instead of "nil" for creation version

### DIFF
--- a/core/src/main/scala/io/github/jchapuis/leases4s/impl/K8sHelpers.scala
+++ b/core/src/main/scala/io/github/jchapuis/leases4s/impl/K8sHelpers.scala
@@ -36,7 +36,7 @@ object K8sHelpers {
       annotations: List[Annotation],
       acquireTime: Instant,
       leaseDuration: FiniteDuration
-  ): v1.Lease = v1LeaseFor(id, holderID, labels, annotations, Some(Version.Nil), acquireTime, None, leaseDuration)
+  ): v1.Lease = v1LeaseFor(id, holderID, labels, annotations, Some(Version.Zero), acquireTime, None, leaseDuration)
 
   def leaseIDFromK8s(lease: v1.Lease): Option[LeaseID] = lease.metadata.flatMap(_.name).flatMap(LeaseID(_))
 

--- a/core/src/main/scala/io/github/jchapuis/leases4s/impl/model/Version.scala
+++ b/core/src/main/scala/io/github/jchapuis/leases4s/impl/model/Version.scala
@@ -9,7 +9,7 @@ private[impl] object Version {
   /** The version of a lease that has not been acquired yet
     *   - this is necessary to enable concurrency control on lease creation
     */
-  val Nil: Version = Version("nil")
+  val Zero: Version = Version("0")
 
   implicit def toStr(version: Version): String = version.value
 }


### PR DESCRIPTION
Kube seems happier with in64 values as it uses ETCD mod_revision

Resolves: #40