### PR TITLE
Use create instead of createOrUpdate

### DIFF
--- a/core/src/main/scala/io/github/jchapuis/leases4s/impl/K8sHelpers.scala
+++ b/core/src/main/scala/io/github/jchapuis/leases4s/impl/K8sHelpers.scala
@@ -36,7 +36,7 @@ object K8sHelpers {
       annotations: List[Annotation],
       acquireTime: Instant,
       leaseDuration: FiniteDuration
-  ): v1.Lease = v1LeaseFor(id, holderID, labels, annotations, Some(Version.Zero), acquireTime, None, leaseDuration)
+  ): v1.Lease = v1LeaseFor(id, holderID, labels, annotations, version = None, acquireTime, None, leaseDuration)
 
   def leaseIDFromK8s(lease: v1.Lease): Option[LeaseID] = lease.metadata.flatMap(_.name).flatMap(LeaseID(_))
 

--- a/core/src/main/scala/io/github/jchapuis/leases4s/impl/KubeLeaseRepository.scala
+++ b/core/src/main/scala/io/github/jchapuis/leases4s/impl/KubeLeaseRepository.scala
@@ -129,7 +129,7 @@ private[impl] class KubeLeaseRepository[F[_]: Async: Random: Logger](
       _   <- OptionT.liftF(nextAcquiredLeaseFor(id, holderID).flatTap(deferredCreatedLease.complete).start)
       now <- OptionT.liftF(Clock[F].realTimeInstant)
       status <- OptionT.liftF(
-        api.createOrUpdate(k8sLease(id, holderID, labels, annotations, now, parameters.leaseDuration))
+        api.create(k8sLease(id, holderID, labels, annotations, now, parameters.leaseDuration))
       )
       _ <- OptionT.liftF(
         if (!status.isSuccess) Logger[F].warn(show"Failed to create lease $id for $holderID: ${status.reason}")

--- a/core/src/main/scala/io/github/jchapuis/leases4s/impl/model/Version.scala
+++ b/core/src/main/scala/io/github/jchapuis/leases4s/impl/model/Version.scala
@@ -5,11 +5,5 @@ import scala.language.implicitConversions
 private[impl] final case class Version(value: String) extends AnyVal
 
 private[impl] object Version {
-
-  /** The version of a lease that has not been acquired yet
-    *   - this is necessary to enable concurrency control on lease creation
-    */
-  val Zero: Version = Version("0")
-
   implicit def toStr(version: Version): String = version.value
 }


### PR DESCRIPTION
We were using createOrUpdate to make sure we overwrite any stray lease. But this was unnecessary extra caution as we anyway explicitly delete any stray lease. The problem with createOrUpdate is that for the create case, we need to provide a some version to avoid overwriting a legit lease, which isn't officially supported.